### PR TITLE
fix: 在 iframe 内注入 Ruffle，修复 Windows「渔港/后室」Flash 失效 (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 修复
 - 「控制透明浏览器」(urlWindowOpen) 弹出窗口无法关闭：原代码显式调用了 `setClosable(false)` 禁用关闭按钮，改为可关闭，并监听 `closed` 事件联动关闭父控制面板，避免遗留孤儿窗口（[#3](https://github.com/xuemian168/qqpet_automation/issues/3)）
+- 「渔港」/「后室」iframe 内 `<embed src="*.swf">` 在 Windows 上回退到原生 Flash 插件失效：iframe 内文档（`indexOnLine.html`）未注入 Ruffle，外层 `app.html` 的 Ruffle 不会被 iframe 自动继承。改为在两个 `indexOnLine.html` 内直接加载 `../../js/ruffle/ruffle.js` 并配置 `RufflePlayer`，由 Ruffle polyfill `<embed>`（[#2](https://github.com/xuemian168/qqpet_automation/issues/2)）
 
 ## [1.3.2] - 2026-05-01
 

--- a/qq-pet-macos/src/windows/popups/backRoom/indexOnLine.html
+++ b/qq-pet-macos/src/windows/popups/backRoom/indexOnLine.html
@@ -12,6 +12,18 @@
     }
   </style>
   <title>Document</title>
+  <script>
+    window.RufflePlayer = window.RufflePlayer || {};
+    window.RufflePlayer.config = {
+      autoplay: "on",
+      unmuteOverlay: "hidden",
+      warnOnUnsupportedContent: false,
+      polyfills: true,
+      letterbox: "off",
+      wmode: "transparent"
+    };
+  </script>
+  <script src="../../js/ruffle/ruffle.js"></script>
   <script src="./cmd.js"></script>
   <script src="./indexOnLine.js"></script>
 </head>

--- a/qq-pet-macos/src/windows/popups/fishing/indexOnLine.html
+++ b/qq-pet-macos/src/windows/popups/fishing/indexOnLine.html
@@ -12,6 +12,18 @@
     }
   </style>
   <title>Document</title>
+  <script>
+    window.RufflePlayer = window.RufflePlayer || {};
+    window.RufflePlayer.config = {
+      autoplay: "on",
+      unmuteOverlay: "hidden",
+      warnOnUnsupportedContent: false,
+      polyfills: true,
+      letterbox: "off",
+      wmode: "transparent"
+    };
+  </script>
+  <script src="../../js/ruffle/ruffle.js"></script>
   <script src="./indexOnLine.js"></script>
 </head>
 


### PR DESCRIPTION
## Summary

- 修复 issue #2：Windows 上「渔港」打开后提示 Flash「插件失效」。
- 根因：`fishing/indexOnLine.html` 直接 `<embed src="./main.swf">`，但 Ruffle 只在外层 `src/windows/app.html` 注入，**iframe 子文档不会自动继承外层脚本**；现代 Chromium 已不再内置 Flash，且 macOS 端 `webPreferences.plugins: false` 也走不通原生回退路径，结果就是「插件失效」。
- 修复方式：在 iframe 内文档头部直接加载 Ruffle 并配置 `RufflePlayer`，由 Ruffle 在同一文档里 polyfill `<embed>`。
- 同样的 bug 模式存在于 `backRoom/indexOnLine.html`（后室），一并修复。

## Changes

| 文件 | 变更 |
|---|---|
| `qq-pet-macos/src/windows/popups/fishing/indexOnLine.html` | 注入 Ruffle 配置 + `../../js/ruffle/ruffle.js` |
| `qq-pet-macos/src/windows/popups/backRoom/indexOnLine.html` | 同上 |
| `CHANGELOG.md` | Unreleased 段补一条修复记录 |

```diff
+  <script>
+    window.RufflePlayer = window.RufflePlayer || {};
+    window.RufflePlayer.config = {
+      autoplay: "on", unmuteOverlay: "hidden",
+      warnOnUnsupportedContent: false, polyfills: true,
+      letterbox: "off", wmode: "transparent"
+    };
+  </script>
+  <script src="../../js/ruffle/ruffle.js"></script>
   <script src="./indexOnLine.js"></script>
```

路径校验：express 静态服务把 `src/` 挂在 `/{fileName}/`，iframe URL 形如 `…/windows/popups/fishing/indexOnLine.html`，相对路径 `../../js/ruffle/ruffle.js` 解析为 `…/windows/js/ruffle/ruffle.js`（实际 `src/windows/js/ruffle/ruffle.js`，文件已存在）。

## Test plan

- [ ] Windows 11，Setup 安装版：打开「渔港」→ Flash 正常加载，没有「插件失效」提示
- [ ] Windows 11：打开「后室」→ 同上验证
- [ ] macOS：打开「渔港」与「后室」→ 不破坏现有可用路径（Ruffle 已在外层 app.html 用过，重复加载/配置不影响）
- [ ] DevTools Console（如能调出）应能看到 Ruffle 启动日志，无 ruffle.js 404
- [ ] 渔港游戏内交互（购买饲料、放鱼、收获）行为与历史版本一致

## Notes

- 不依赖 `webPreferences.plugins`，因为现代 Electron/Chromium 即使开启也没有可用 Flash 插件。
- 仅改了源 HTML，未触碰 `dist`/`qq_pet_asar`/`qq_pet_extracted` 等衍生目录，下次打包自动产出新版本。

Fixes #2